### PR TITLE
Support reading cached G4DB cross sections from disk

### DIFF
--- a/include/G4DarkBreM/ElementXsecCache.h
+++ b/include/G4DarkBreM/ElementXsecCache.h
@@ -51,6 +51,15 @@ class ElementXsecCache {
   void stream(std::ostream& o) const;
 
   /**
+   * Read the entire table from the input stream.
+   *
+   * @param[in] in istream to read from 
+   */
+  void stream(std::istream& i);
+
+
+
+  /**
    * Overload the streaming operator for ease
    *
    * @param[in] o ostream to write to

--- a/src/G4DarkBreM/ElementXsecCache.cxx
+++ b/src/G4DarkBreM/ElementXsecCache.cxx
@@ -15,6 +15,34 @@ G4double ElementXsecCache::get(G4double energy, G4double A, G4double Z) {
   return the_cache_.at(key);
 }
 
+void ElementXsecCache::stream(std::istream& i) {
+  // Buffer for each line
+  std::string buffer{};
+  // Buffer for ',' characters
+  char charbuffer{};
+  // Skip the header
+  std::getline(i, buffer);
+  double small{1e-3};
+  while (std::getline(i, buffer)) {
+    // Skip empty lines (avoid parsing as 0s)
+    if (buffer == "") {
+      continue;
+    }
+    std::stringstream ss{buffer};
+    ss >> std::setprecision(std::numeric_limits<double>::digits10 + 1);
+    double E{};
+    double A{};
+    double Z{};
+    double xsec{};
+    // Manually parsing CSV sure is fun and not bugprone at all
+    ss >> A >> charbuffer;
+    ss >> Z >> charbuffer;
+    ss >> E >> charbuffer;
+    ss >> xsec;
+    key_t key{computeKey(E, A, Z)};
+    the_cache_[key] = xsec * CLHEP::picobarn;
+  }
+}
 void ElementXsecCache::stream(std::ostream& o) const {
   o << "A [au],Z [protons],Energy [MeV],Xsec [pb]\n"
     << std::setprecision(std::numeric_limits<double>::digits10 +


### PR DESCRIPTION
First draft at being able to read back a cache from disk. Took some faffing around because CSV parsing with iostreams is unpleasant (and I only just now realized that maybe we could use boost for something?) but I've tested it with the `xsec_calc` app by 
- Creating a cache attached to the model 
- Fill it when we calculate the XS with `ElementXsecCache::get` 
- Stream it to a separate file (the output of `xsec_calc` isn't compatible with the `ElementXsecCache::stream` format) 
- Create a new cache and read the previous cache's output with it 
- Write the second cache to a separate file 
- Diff 

I ran this with an energy range of 0 - 100 GeV and these were the only differences 
```diff
748c748
< 183,74,74700,8289000278.843637
---
> 183,74,74700,8289000278.843638
755c755
< 183,74,75400,8313209739.499187
---
> 183,74,75400,8313209739.499188
823c823
< 183,74,82200,8538021432.452312
---
> 183,74,82200,8538021432.452313
```
which are all rounding errors in the last available digit. 

Technically, this is sufficient for me (as in it is all I need for implementing a separate process/model with its own slooooow XS calculation). If we'd want to have this be useful in LDMX-sw, we would need some additional features and I'm less sure that this is an urgent problem to solve and it has some concerns from a reproducibility perspective (where does the cache go, what if people mix up caches with different xsec calculation methods etc). 

Would love to hear your thoughts on it, Tom (not tagging actively because it is a saturday...)