### PR TITLE
drop back tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
       - '**.md'
       - '.github/workflows/docs.yml'
 
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,66 +11,19 @@ on:
       - 'docs/**'
       - '**.md'
       - '.github/workflows/docs.yml'
-
   workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        boost: [1.80.0, 1.71.0, 1.68.0]
-        geant4: [11.0.3, 10.7.4, 10.2.3]
-    env:
-      INSTALL_PREFIX: ${{github.workspace}}/deps
+    container:
+      image: ldmx/dev:latest
     steps:
       -
         name: checkout source
         uses: actions/checkout@v4
       -
-        name: cache dependencies
-        id: cache-deps
-        uses: actions/cache@v4
-        with:
-          path: ${{env.INSTALL_PREFIX}}
-          key: new-boost-${{matrix.boost}}-geant4-${{matrix.geant4}}
-      -
-        name: install boost
-        if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir dep-src
-          boost_version=${{matrix.boost}}
-          wget -q -O - https://archives.boost.io/release/${boost_version}/source/boost_${boost_version//./_}.tar.gz |\
-            tar -xz --strip-components=1 --directory dep-src
-          cd dep-src
-          ./bootstrap.sh --with-libraries=iostreams,math,regex
-          ./b2 install --prefix=${INSTALL_PREFIX}
-          cd ..
-          rm -rf dep-src
-      -
-        name: install geant4
-        if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-        run: |
-          python3 -m pip install cmake==3.22
-          cmake --version
-          mkdir dep-src
-          wget -q -O - https://github.com/geant4/geant4/archive/refs/tags/v${{matrix.geant4}}.tar.gz |\
-            tar -xz --strip-components=1 --directory dep-src
-          # old versions of Geant4 clash with newer GCC 11 compiler
-          #   luckily the fix is only in one file and is internal to Geant4
-          sed -i 's|fsqrt|g4fsqrt|g' dep-src/source/persistency/ascii/src/G4tgrEvaluator.cc
-          cmake \
-            -DGEANT4_INSTALL_EXAMPLES=OFF \
-            -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
-            -B dep-src/build \
-            -S dep-src
-          cmake --build dep-src/build --target install
-          rm -rf dep-src 
-      -
         name: test compile
         run: |
-          source ${INSTALL_PREFIX}/bin/geant4.sh
-          export CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
           cmake -B build -S . 
           cmake --build build
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.12)
-
 project(G4DarkBreM
   VERSION 2.1.0
   DESCRIPTION "Dark brem simulation integrated within Geant4"
@@ -12,6 +11,9 @@ find_package(Boost 1.68 REQUIRED COMPONENTS iostreams)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Force include cstdint before any other headers to fix CLHEP issues
+add_compile_options(-include cstdint)
+
 include(${Geant4_USE_FILE})
 
 add_library(G4DarkBreM SHARED
@@ -21,8 +23,10 @@ add_library(G4DarkBreM SHARED
   src/G4DarkBreM/G4DarkBreMModel.cxx
   src/G4DarkBreM/G4DarkBremsstrahlung.cxx
   src/G4DarkBreM/ParseLibrary.cxx)
+
 target_link_libraries(G4DarkBreM PUBLIC ${Geant4_LIBRARIES} Boost::headers Boost::iostreams)
 target_include_directories(G4DarkBreM PUBLIC include)
+
 install(TARGETS G4DarkBreM DESTINATION lib)
 
 add_executable(g4db-extract-library app/extract_library.cxx)
@@ -40,4 +44,3 @@ install(TARGETS g4db-scale DESTINATION bin)
 add_executable(g4db-simulate app/simulate.cxx)
 target_link_libraries(g4db-simulate PRIVATE G4DarkBreM ${Geant4_LIBRARIES})
 install(TARGETS g4db-simulate DESTINATION bin)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
+
 project(G4DarkBreM
   VERSION 2.1.0
   DESCRIPTION "Dark brem simulation integrated within Geant4"
@@ -7,12 +8,6 @@ project(G4DarkBreM
 # Search for Geant4 and load its settings
 find_package(Geant4 10.2.3 REQUIRED)
 find_package(Boost 1.68 REQUIRED COMPONENTS iostreams)
-
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# Force include cstdint before any other headers to fix CLHEP issues
-add_compile_options(-include cstdint)
 
 include(${Geant4_USE_FILE})
 
@@ -23,10 +18,8 @@ add_library(G4DarkBreM SHARED
   src/G4DarkBreM/G4DarkBreMModel.cxx
   src/G4DarkBreM/G4DarkBremsstrahlung.cxx
   src/G4DarkBreM/ParseLibrary.cxx)
-
 target_link_libraries(G4DarkBreM PUBLIC ${Geant4_LIBRARIES} Boost::headers Boost::iostreams)
 target_include_directories(G4DarkBreM PUBLIC include)
-
 install(TARGETS G4DarkBreM DESTINATION lib)
 
 add_executable(g4db-extract-library app/extract_library.cxx)
@@ -44,3 +37,4 @@ install(TARGETS g4db-scale DESTINATION bin)
 add_executable(g4db-simulate app/simulate.cxx)
 target_link_libraries(g4db-simulate PRIVATE G4DarkBreM ${Geant4_LIBRARIES})
 install(TARGETS g4db-simulate DESTINATION bin)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ project(G4DarkBreM
 find_package(Geant4 10.2.3 REQUIRED)
 find_package(Boost 1.68 REQUIRED COMPONENTS iostreams)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include(${Geant4_USE_FILE})
 
 add_library(G4DarkBreM SHARED


### PR DESCRIPTION
We don't have the dev time to maintain backwards compatibility tests with old G4 versions that are quickly falling out of compatibility with newer compilers. Switching to just test-compiling within the ldmx/dev image and further testing should be done manually.